### PR TITLE
feature: process show/season/episode ratings grouped by shows

### DIFF
--- a/Jellyfin.Plugin.MdbListRatings/ScheduledTasks/UpdateRatingsTask.cs
+++ b/Jellyfin.Plugin.MdbListRatings/ScheduledTasks/UpdateRatingsTask.cs
@@ -6,6 +6,8 @@ using System.Threading.Tasks;
 using Jellyfin.Data.Enums;
 using Microsoft.Extensions.Logging;
 using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Movies;
+using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Model.Tasks;
 
 namespace Jellyfin.Plugin.MdbListRatings.ScheduledTasks;
@@ -84,6 +86,57 @@ public sealed class UpdateRatingsTask : IScheduledTask
             Recursive = true,
             IncludeItemTypes = new[] { BaseItemKind.Movie, BaseItemKind.Series, BaseItemKind.Season, BaseItemKind.Episode }
         });
+
+        static Guid GetSeriesGroupKey(BaseItem item)
+        {
+            return item switch
+            {
+                Season season => season.Series?.Id ?? Guid.Empty,
+                Episode episode => episode.Series?.Id ?? Guid.Empty,
+                _ => item.Id
+            };
+        }
+
+        static int GetItemKindOrder(BaseItem item)
+        {
+            return item switch
+            {
+                Series => 0,
+                Season => 1,
+                Episode => 2,
+                _ => 3
+            };
+        }
+
+        static int GetSeasonOrder(BaseItem item)
+        {
+            return item switch
+            {
+                Season season => season.IndexNumber ?? 0,
+                Episode episode => episode.ParentIndexNumber ?? 0,
+                _ => 0
+            };
+        }
+
+        static int GetEpisodeOrder(BaseItem item)
+        {
+            return (item as Episode)?.IndexNumber ?? 0;
+        }
+
+        // Process each show's seasons and episodes consecutively instead of
+        // Jellyfin's default interleaved order,
+        // Keeps the age of ratings of Episodes of a show consistent
+        // also enables API response reuse while they are still hot in the in-memory caches.
+        // Grouped by the series' Guid (not its name) so shows with identical titles across
+        // different libraries are never interleaved with each other.
+        // Movies are standalone items and are processed last.
+        items = items
+            .OrderBy(item => item is Movie)
+            .ThenBy(GetSeriesGroupKey)
+            .ThenBy(GetItemKindOrder)
+            .ThenBy(GetSeasonOrder)
+            .ThenBy(GetEpisodeOrder)
+            .ToArray();
 
         var total = items.Count;
         if (total == 0)


### PR DESCRIPTION
Currently the Update Task processes all TV Shows ordered by Episode Numbers (show A, Season 01, Episode 01 -> Show b, Season 01, Episode 01 -> ... -> show X, Season Y, Episode Z)

This PR reorders the list of shows/seasons/episodes so that all elements of a show are processed as a whole instead of the old episode ordering.

Through this we make sure the ratings for a show are all roughly the same age even if our update takes longer due to API limits.