### PR TITLE
feature: Jellyfin 12.0 support

### DIFF
--- a/Jellyfin.Plugin.MdbListRatings/Jellyfin.Plugin.MdbListRatings.csproj
+++ b/Jellyfin.Plugin.MdbListRatings/Jellyfin.Plugin.MdbListRatings.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>
@@ -12,8 +12,8 @@
     <AssemblyVersion>1.0.0.6</AssemblyVersion>
     <FileVersion>1.0.0.6</FileVersion>
     <InformationalVersion>1.0.0.6</InformationalVersion>
-    <!-- IMPORTANT: match your Jellyfin Server version (e.g. 10.11.5) -->
-    <JellyfinVersion>10.11.5</JellyfinVersion>
+    <!-- IMPORTANT: match your Jellyfin Server version (e.g. 12.0.0) -->
+    <JellyfinVersion>12.0.0</JellyfinVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -32,11 +32,6 @@
     <EmbeddedResource Include="AwardData\**\*.json" />
     <EmbeddedResource Include="AwardData\**\*.yml" />
     <EmbeddedResource Include="AwardData\**\*.yaml" />
-  </ItemGroup>
-
-  <!-- Needed for ASP.NET Core MVC attributes/controllers (plugin API endpoint) -->
-  <ItemGroup>
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This PR just bumps the TargetFramework (net9.0 -> net10.0) and the JellyfinVersion (10.11.5 -> 12.0.0) to be compatible with the new 12.0 Version 

I've also removed the explicit FrameworkReference Microsoft.AspNetCore.App because I had problems compiling it with it (MVC types should come transitively from Jellyfin.Controller/Model)

This PR does merge cleanly with my other ones.